### PR TITLE
fix: centering for children container

### DIFF
--- a/src/CircularProgress.tsx
+++ b/src/CircularProgress.tsx
@@ -467,7 +467,7 @@ export const CircularProgress = Object.assign(CircularProgressRoot, {
 
 const styles = StyleSheet.create({
   childrenContainer: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     justifyContent: 'center',
     alignItems: 'center',
   },


### PR DESCRIPTION
`StyleSheet.absoluteFillObject` was [removed in RN 0.85](https://reactnative.dev/blog/2026/04/07/react-native-0.85#stylesheetabsolutefillobject-removed), which has resulted in the children container no longer being centred. This fix just switches over the appropriate line to use the recommended `StyleSheet.absoluteFill` instead.